### PR TITLE
Changed flags icon in emoji picker

### DIFF
--- a/src/modules/popouts/_emoji_picker.scss
+++ b/src/modules/popouts/_emoji_picker.scss
@@ -120,8 +120,7 @@
                 content: "\ED58"; // EmojiTabSymbols
             }
             &[aria-label="flags"]::before{
-                content: "🏳‍🌈";
-                @include TypeBody;
+                content: "\ED5B"; // EmojiSwatch
             }
         }
     }


### PR DESCRIPTION
Changed the previous flag icon in emoji picker to EmojiSwatch to respect the fluent design
![%pn-ItzPeto-06-03-2022-17-23-12](https://user-images.githubusercontent.com/46417703/156931933-5e55cf0f-e4ce-4614-9b34-052b0ecf2d5b.png)