### PR TITLE
Added, updated and hidden icons

### DIFF
--- a/src/modules/home/_main.scss
+++ b/src/modules/home/_main.scss
@@ -103,10 +103,14 @@ html[lang^="en-"].theme-dark .container-2cd8Mz{
         &::before{
             @include FontIconFluent;
             color: $TextFillColorSecondary;
-            content: "\e711"; // Cancel
         }
         svg{
             display: none;
         }
     }
+}
+
+// Pending friend requests Cancel button
+[aria-label="Cancel"]::before{
+    content: "\E711"; // Cancel
 }

--- a/src/modules/home/_main.scss
+++ b/src/modules/home/_main.scss
@@ -103,6 +103,7 @@ html[lang^="en-"].theme-dark .container-2cd8Mz{
         &::before{
             @include FontIconFluent;
             color: $TextFillColorSecondary;
+            content: "\e711"; // Cancel
         }
         svg{
             display: none;

--- a/src/modules/icons/_context_menu.scss
+++ b/src/modules/icons/_context_menu.scss
@@ -75,7 +75,7 @@
         content: "\F157"; // DialShape2
     }
     &[id="user-settings-cog-Experiments"]::before{
-        content: "\f1ad"; // WindowsInsider
+        content: "\E9cA"; // Frigid
     }
     &[id="user-settings-cog-Developer_Options"]::before{
         content: "\ec7a"; // DeveloperTools
@@ -352,6 +352,9 @@
     &[id="message-thread"]::before{
         content: "\E15C"; // ShowResults
     }
+    &[id="message-apps"]::before{
+        content: "\E74C"; // OEM
+    }
     &[id="message-mark-unread"]::before{
         content: "\E119"; // Mail
     }
@@ -376,6 +379,9 @@
     &[id="message-open-native-link"]::before{
         content: "\E8A7"; // OpenInNewWindow
     }
+    &[id="message-devmode-copy-id"]::before{
+        content: "\E943"; // Code
+    }
 }
 // Message action
 .theme-dark .menu-1QACrS .item-1OdjEX{
@@ -391,6 +397,9 @@
     &[id="message-actions-thread"]::before{
         content: "\E15C"; // ShowResults
     }
+    &[id="message-actions-apps"]::before{
+        content: "\E74C"; // OEM
+    }
     &[id="message-actions-mark-unread"]::before{
         content: "\E119"; // Mail
     }
@@ -405,6 +414,9 @@
     }
     &[id="message-actions-delete"]::before{
         content: "\E107"; // Delete
+    }
+    &[id="message-actions-copy-id"]::before{
+        content: "\E943"; // Code
     }
 }
 

--- a/src/modules/icons/_context_menu.scss
+++ b/src/modules/icons/_context_menu.scss
@@ -94,6 +94,9 @@
     &[id="user-context-change-nickname"]::before{
         content: "\E136"; // ContactInfo
     }
+    &[id="user-context-apps"]::before{
+        content: "\E74C"; // OEM
+    }
     &[id="user-context-message-user"]::before{
         content: "\E15F"; // Message
     }
@@ -138,6 +141,9 @@
     }
     &[id="user-context-roles"]::before{
         content: "\EC1B"; // Badge
+    }
+    &[id="user-context-devmode-copy-id"]::before{
+        content: "\E943"; // Code
     }
     &[id="user-context-voice-move"]::before{
         content: "\E759"; // SIPMove
@@ -209,6 +215,12 @@
     }
     &[id="channel-context-channel-copy-link"]::before{
         content: "\E167"; // Link
+    }
+    &[id="channel-context-delete-channel"]::before{
+        content: "\E107"; // Delete
+    }
+    &[id="channel-context-devmode-copy-id"]::before{
+        content: "\E943"; // Code
     }
     &[id="channel-context-hide-voice-names"]::before{
         content: "\E16A"; // HideBcc

--- a/src/modules/icons/settings/_settings.scss
+++ b/src/modules/icons/settings/_settings.scss
@@ -96,8 +96,8 @@
             content: "\F157"; // DialShape2
         }
         .item-3XjbnG[aria-controls="experiments-tab"]::after{ // Experiments
-            content: "\f1ad"; // WindowsInsider
-        } // TODO: 2022-03-06 - Find better icon
+            content: "\E9cA"; // Frigid
+        }
         .item-3XjbnG[aria-controls="developer-options-tab"]::after{ // Developer Options
             content: "\ec7a"; // DeveloperOptions
         }

--- a/src/modules/main/guilds/_guilds.scss
+++ b/src/modules/main/guilds/_guilds.scss
@@ -88,22 +88,6 @@
             }
         }
 
-        // Inbox
-        .iconButton-2z1iK7 { // NOTE 2022-03-07 - Updated Inbox icon when Experiment 2022-01_inbox_redesign is on. No hover effect however unlike the Home button. Please check.
-            &[aria-label="Inbox"] {
-                background-color: transparent;
-                &::before{
-                    content: "\E715"; // Mail
-                    color: $TextFillColorPrimary;
-                    @include FontIconFluent;
-                    font-size: 16px;
-                }
-                svg{
-                    display: none;
-                }
-            }
-        }
-
         // Home
         .wrapper-3kah-n{
             &[aria-label="Home"]{

--- a/src/modules/main/guilds/_guilds.scss
+++ b/src/modules/main/guilds/_guilds.scss
@@ -88,6 +88,22 @@
             }
         }
 
+        // Inbox
+        .iconButton-2z1iK7 { // NOTE 2022-03-07 - Updated Inbox icon when Experiment 2022-01_inbox_redesign is on. No hover effect however unlike the Home button. Please check.
+            &[aria-label="Inbox"] {
+                background-color: transparent;
+                &::before{
+                    content: "\E715"; // Mail
+                    color: $TextFillColorPrimary;
+                    @include FontIconFluent;
+                    font-size: 16px;
+                }
+                svg{
+                    display: none;
+                }
+            }
+        }
+
         // Home
         .wrapper-3kah-n{
             &[aria-label="Home"]{

--- a/src/modules/popouts/_user.scss
+++ b/src/modules/popouts/_user.scss
@@ -117,6 +117,11 @@
         display: none;
     }
 
+    // Edit profile button
+    .pencilContainer-18TrEJ {
+        display: none; // NOTE 2022-03-07 Hide non-functional Edit profile button
+    }
+
     // Note
     .note-Go5ZP2{
         margin: 0;


### PR DESCRIPTION
# Changes made
- Added a Cancel icon on Pending friend requests.
- Updated the Experiments icon into a more fitting icon.
- Hidden a non-functional Edit profile button. This should address #64 in the meantime.
- Updated Inbox icon when `2022-01_inbox_redesign` experiment is on which moves the Inbox on top of the Home button. **[This](https://github.com/TakosThings/Fluent-Discord/commit/ab5a96c57495c2258080ab82c7f586d71c04b4b9) needs attention—no hover effect.**
- Added a bunch of missing icons from user and channel/category context menus.
	- User
		- [x] Apps
		- [x] Copy ID
		- [x] ~~Play on Spotify~~
		- [x] ~~Listen Along~~
	- Channel/Category
		-  [x] Delete Channel/Category
		-  [x] Copy ID