### PR TITLE
fix(ReadAllNotifications): button overlay

### DIFF
--- a/src/modules/betterdiscord/plugins/_DevilBro.ReadAllNotificationsButton.scss
+++ b/src/modules/betterdiscord/plugins/_DevilBro.ReadAllNotificationsButton.scss
@@ -12,6 +12,9 @@
             background-color: $ControlFillColorDefault;
         }
     }
+    .innerFrame-8Hg64E::before {
+        display: none !important;
+    }
 }
 
 // Message action


### PR DESCRIPTION
With this PR the overlay (on hover effect) of the "Read All" button will be hidden.

Before:
![image](https://user-images.githubusercontent.com/5560558/209564563-031322db-c5fe-4669-8f14-dc82d679faa9.png)
After:
![image](https://user-images.githubusercontent.com/5560558/209564612-b8e3dccc-6208-4eb7-991b-cd9eb0f32fef.png)



This PR closes #201 