### PR TITLE
fix(modules/settings): animate all content container direct descendants

### DIFF
--- a/src/modules/settings/_settings.scss
+++ b/src/modules/settings/_settings.scss
@@ -77,7 +77,7 @@
         opacity: 1;
     }
 }
-.contentColumn__5f80b > div:first-child{
+.contentColumn__5f80b > *{
     animation: fluent-settings-pages-transition 250ms cubic-bezier(0, 0, 0, 1);
 }
 


### PR DESCRIPTION
fixes transition on _Profiles_, _Family Center_, _Clips_, _Privacy & Safety_ and some other pages