### PR TITLE
New line if too many badges & fix bg color

### DIFF
--- a/src/modules/modals/_user.scss
+++ b/src/modules/modals/_user.scss
@@ -54,4 +54,10 @@
             border-radius: 50%;
         }
     }
+
+    // Profile badges
+    [class^="profileBadges"] {
+        flex: none;
+        background-color: var(--profile-body-background-color);
+    }
 }


### PR DESCRIPTION
# What changes?
1. Currently, when you have too many badges, it bugs out the view - making the container a flex fixes the issue.
2. The background of the container seems to have vanished - brings it back.

| Before | After |
| ------------- | ------------- |
| ![Screenshot 2024-04-06 202815](https://github.com/TakosThings/Fluent-Discord/assets/24621566/ba8706af-bfbd-4b0e-a19f-0036511751a2) | ![Screenshot 2024-04-06 202820](https://github.com/TakosThings/Fluent-Discord/assets/24621566/86bc7515-4963-470b-99be-f4a1bf734be9) |
| ![Screenshot 2024-04-06 202755](https://github.com/TakosThings/Fluent-Discord/assets/24621566/29365d7a-de20-40c1-aecd-67b0ba834f13) | ![Screenshot 2024-04-06 202800](https://github.com/TakosThings/Fluent-Discord/assets/24621566/6c3ebe35-4ce3-488a-bca3-d51d7a9be833) |



